### PR TITLE
CLN scoreLevel 함수 함수명 수정

### DIFF
--- a/테트리스_완성-점수처리.c
+++ b/테트리스_완성-점수처리.c
@@ -405,7 +405,7 @@ void Array_down(int column)
 
 }
 //레벨 스코어 출력
-void scoreLevel(void)
+void Print_scorelevel(void)
 {
 	setCursor(40, 3);
 	printf("★레벨10 게임 클리어★");
@@ -423,7 +423,7 @@ void countScore(void)
 		level += 1;
 		speed -= 30;
 	}
-	scoreLevel();
+	Print_scorelevel();
 }
 /* 1~10까지 행의 열 전체가 1로되면 블록사라짐.
 	사라지면 array_down함수 실행 */
@@ -605,7 +605,7 @@ int main()
 {
 	removeCursor(); //커서 깜박이 제거
 	showBoard(); //보드 출력
-	scoreLevel();
+	Print_scorelevel();
 	Run(); //보드 출력 움직임
 	getchar();
 }


### PR DESCRIPTION
- 변경한 이유
 scoreLevel 함수명은 함수인지 분별하기 어렵다고 판단.
 또한, score와 level을 출력해주는 기능을 표현하긴 부족하다고 판단함.

- 변경사항
 scoreLevel을 Print_scorelevel으로 변경함.