### PR TITLE
CLN countScore 함수 함수명 수정

### DIFF
--- a/테트리스_완성-점수처리.c
+++ b/테트리스_완성-점수처리.c
@@ -415,7 +415,7 @@ void Print_scorelevel(void)
 	printf("점수:%d\n", score);
 }
 //레벨 스코어 계산
-void countScore(void)
+void Count_score(void)
 {
 	score += 10;
 	if (score % 30 == 0)
@@ -452,7 +452,7 @@ void Check_line(void)
 						printf("  ");
 					}
 					//행 기준으로 블록 내리기
-					countScore();
+					Count_score();
 					Array_down(y);
 				}
 


### PR DESCRIPTION
- 변경한 이유
 countScore 함수명은 함수인지 분별하기 어렵다고 판단함.

- 변경사항
 countScore을 Count_score로 변경함.