### PR TITLE
CLN removeCursor 함수 함수명 수정

### DIFF
--- a/테트리스_완성-점수처리.c
+++ b/테트리스_완성-점수처리.c
@@ -198,7 +198,7 @@ int block_array[][4][4] = {
 							{0, 0, 0, 0} },
 
 };
-void removeCursor(void)
+void Remove_cursor(void)
 {
 	CONSOLE_CURSOR_INFO curInfo;
 	GetConsoleCursorInfo(GetStdHandle(STD_OUTPUT_HANDLE), &curInfo);
@@ -603,7 +603,7 @@ void Run(void)
 
 int main()
 {
-	removeCursor(); //커서 깜박이 제거
+	Remove_cursor(); //커서 깜박이 제거
 	showBoard(); //보드 출력
 	Print_scorelevel();
 	Run(); //보드 출력 움직임


### PR DESCRIPTION
- 변경한 이유
 removeCursor 함수명은 함수인지 분별하기 어렵다고 판단함.

- 변경사항
 removeCursor 을 Remove_cursor 으로 수정함
