### PR TITLE
EOR 블록 모양 오류 해결

### DIFF
--- a/테트리스_완성-점수처리.c
+++ b/테트리스_완성-점수처리.c
@@ -587,11 +587,7 @@ void Run(void)
    {
       Initial(CBLOCK_X, CBLOCK_Y); 
 
-      block = (rand() % RAND) * 4; //블록 모양 결정
-      block = rand() % RAND;
-      block = rand() % 7;
-      block = block * 4;
-      block = 6;
+      block = (rand() % 7) * 4;
 
       if (Game_win())
       {


### PR DESCRIPTION
- 변경한 이유
블록모양이 random하게 나오지 않고 한가지만 나옴.

- 변경 사항
기존 블록 모양을 결정하는 코드를 block = (rand() % 7) * 4 으로 수정함.